### PR TITLE
Bump scalaVersion to 2.12.6

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -9,7 +9,7 @@ lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "$organization$",
   // Semantic versioning http://semver.org/
   version := "0.1.0-SNAPSHOT",
-  scalaVersion := "2.11.12",
+  scalaVersion := "2.12.6",
   scalacOptions ++= Seq("-target:jvm-1.8",
                         "-deprecation",
                         "-feature",


### PR DESCRIPTION
Should we start pushing for 2.12 to get a wider audience and get more input if something breaks?