### PR TITLE
Revert "Update flink-runtime to 1.11.2 (#91)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val scioVersion = "0.9.4"
 val beamVersion = "2.23.0"
-val flinkVersion = "1.11.2"
+val flinkVersion = "1.10.2"
 val sparkVersion = "3.0.1"
 
 lazy val root = project

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -9,7 +9,7 @@ $endif$
 val scioVersion = "0.9.4"
 val beamVersion = "2.23.0"
 $if(FlinkRunner.truthy)$
-val flinkVersion = "1.11.2"
+val flinkVersion = "1.10.2"
 $endif$
 $if(SparkRunner.truthy)$
 val sparkVersion = "3.0.1"


### PR DESCRIPTION
This reverts commit 2979bc8df1a5e8190d58f92ea04ed63b9fb91c31.

We should keep version in sync with runner