### PR TITLE
Revert spark dependency to 2.4.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val scioVersion = "0.9.4"
 val beamVersion = "2.23.0"
 val flinkVersion = "1.11.2"
-val sparkVersion = "3.0.1"
+val sparkVersion = "2.4.6"
 
 lazy val root = project
   .in(file("."))

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -12,7 +12,7 @@ $if(FlinkRunner.truthy)$
 val flinkVersion = "1.11.2"
 $endif$
 $if(SparkRunner.truthy)$
-val sparkVersion = "3.0.1"
+val sparkVersion = "2.4.6"
 $endif$
 
 lazy val commonSettings = Def.settings(


### PR DESCRIPTION
We should keep version in sync with `beam-runners-spark`