### PR TITLE
Flink compatability still only up to 2.12

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -20,7 +20,9 @@ lazy val commonSettings = Def.settings(
   // Semantic versioning http://semver.org/
   version := "0.1.0-SNAPSHOT",
   $if(FlinkRunner.truthy || SparkRunner.truthy)$
-  scalaVersion := "2.13.6",
+  // scala-steward:off
+  scalaVersion := "2.12.13"
+  // scala-steward:on
   $else$
   scalaVersion := "2.13.3",
   $endif$


### PR DESCRIPTION
Scala steward messed up a previous fix here: https://github.com/spotify/scio.g8/pull/72/files