### PR TITLE
Add confluent resolver for DataflowRunner

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -26,6 +26,9 @@ lazy val commonSettings = Def.settings(
   $else$
   scalaVersion := "2.13.3",
   $endif$
+  $if(DataflowRunner.truthy)$
+  resolvers += "confluent" at "https://packages.confluent.io/maven/",
+  $endif$
   scalacOptions ++= Seq("-target:jvm-1.8",
                         "-deprecation",
                         "-feature",


### PR DESCRIPTION
With DataflowRunner, the sample WordCount cannot be compiled by following error.

```
[error] sbt.librarymanagement.ResolveException: Error downloading io.confluent:kafka-avro-serializer:5.3.2
```