### PR TITLE
Downgrade Spark3 version to match Beam supported

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val scioVersion = "0.11.14"
 val beamVersion = "2.38.0"
 val flinkVersion = "1.13.6"
-val sparkVersion = "3.2.1"
+val sparkVersion = "3.1.2"
 
 lazy val root = project
   .in(file("."))

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -12,7 +12,7 @@ $if(FlinkRunner.truthy)$
 val flinkVersion = "1.13.6"
 $endif$
 $if(SparkRunner.truthy)$
-val sparkVersion = "3.2.1"
+val sparkVersion = "3.1.2"
 $endif$
 
 lazy val commonSettings = Def.settings(


### PR DESCRIPTION
Apache Beam is built on `3.1.2` version. Probably the current version here was set by typo